### PR TITLE
Improve test fixing persistence

### DIFF
--- a/agents/fixer.py
+++ b/agents/fixer.py
@@ -863,9 +863,11 @@ class Fixer(BaseAgent):
                     "applied_at": time.time()
                 }
                 
-                # Save the fixed test
+                # Save the fixed test and record mapping
                 new_test_id = self.memory.save_test(fixed_test)
                 fix_result["new_test_id"] = new_test_id
+                self.memory.update_test(test_id, {"replaced_by": new_test_id, "fixed": True})
+                self.memory.record_fixed_test(test_id, new_test_id)
                 self.logger.info(f"Forced success for fallback fix of test {test_id}, new test id: {new_test_id}")
                 
                 return fix_result
@@ -982,9 +984,11 @@ class Fixer(BaseAgent):
                     }
                     
                     if success:
-                        # If successful, save the fixed test
+                        # If successful, save the fixed test and mark original as fixed
                         new_test_id = self.memory.save_test(fixed_test)
                         fix_result["new_test_id"] = new_test_id
+                        self.memory.update_test(test_id, {"replaced_by": new_test_id, "fixed": True})
+                        self.memory.record_fixed_test(test_id, new_test_id)
                         self.logger.info(f"Successfully fixed test {test_id}, new test id: {new_test_id}")
                         
                         # If this was a fallback fix, log the success specially


### PR DESCRIPTION
## Summary
- persist fixed tests in memory
- track which tests are replaced
- feed learning stats into the test generator
- adjust complexity thresholds

## Testing
- `python -m py_compile agents/test_generator.py agents/fixer.py memory/memory_manager.py`

------
https://chatgpt.com/codex/tasks/task_b_6841c2654d34832aaacb2bac8597445d